### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ pod 'TAKiBeaconManager', '~> 0.1.1'
 ```
 
 ###Requirements
-requires iOS 7 & xCode7
+requires iOS 7 & Xcode7
 
 License
 ---


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
